### PR TITLE
Support alternating requests

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -20,6 +20,23 @@ async def run_two_gets():
         print('\n'.join(map(lambda x: ','.join(map(str, x)), results)))
     logger.info('h2time with 2 GET requests finished')
 
+async def run_two_gets_customize_order():
+    r1 = H2Request('GET', 'https://tom.vg/?1', {'user-agent': ua})
+    r2 = H2Request('GET', 'https://tom.vg/?2', {'user-agent': ua})
+    logger.info('Starting h2time with 2 GET requests')
+    async with H2Time(r1, r2, send_order_pattern="12211", num_request_pairs=5) as h2t:
+        results = await h2t.run_attack()
+        print('\n'.join(map(lambda x: ','.join(map(str, x)), results)))
+    logger.info('h2time with 2 GET requests finished')
+
+async def run_two_gets_always_send_r1_first():
+    r1 = H2Request('GET', 'https://tom.vg/?1', {'user-agent': ua})
+    r2 = H2Request('GET', 'https://tom.vg/?2', {'user-agent': ua})
+    logger.info('Starting h2time with 2 GET requests')
+    async with H2Time(r1, r2, send_order_pattern="1", num_request_pairs=5) as h2t:
+        results = await h2t.run_attack()
+        print('\n'.join(map(lambda x: ','.join(map(str, x)), results)))
+    logger.info('h2time with 2 GET requests finished')
 
 async def run_two_posts():
     post_data = 'x=' + ''.join(random.choices(string.ascii_uppercase + string.digits, k=2000))
@@ -47,6 +64,8 @@ async def run_two_gets_loop():
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(run_two_gets())
+loop.run_until_complete(run_two_gets_customize_order())
+loop.run_until_complete(run_two_gets_always_send_r1_first())
 loop.run_until_complete(run_two_posts())
 loop.run_until_complete(run_two_gets_loop())
 loop.close()


### PR DESCRIPTION
This PR implements alternating requests for Timeless Timing Attacks as described in #1.

An additional parameter `send_order_pattern` has been added to the `H2Time` class initialization. This parameter defines the order in which the requests will be sent.

The parameter is a string of 1's and 2's indicating the order in which the requests should be sent ('1' for `r1-r2`, '2' for `r2-r1`). This pattern is repeated until `num_request_pairs` pairs have been sent.

Examples (with `num_request_pairs = 4`):

|`send_order_pattern`|requests|
|---|---|
|`"12"` (default)|`r1-r2`, `r2-r1`, `r1-r2`, `r2-r1`|
|`"1"` (backward compatibility)|`r1-r2`, `r1-r2`, `r1-r2`, `r1-r2`|
|`"2221"`|`r2-r1`, `r2-r1`, `r2-r1`, `r1-r2`|
|`"222111"`|`r2-r1`, `r2-r1`, `r2-r1`, `r1-r2`|